### PR TITLE
Serve .dmg for /download/ routes

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,3 +1,6 @@
+// Native
+const { extname } = require('path')
+
 // Packages
 const fetch = require('node-fetch')
 const convertStream = require('stream-to-string')
@@ -104,6 +107,8 @@ module.exports = class Cache {
     // Clear list of download links
     this.latest.platforms = {}
 
+    let dmgUrl;
+
     for (const asset of release.assets) {
       const { name, browser_download_url, url, content_type, size } = asset
 
@@ -121,6 +126,12 @@ module.exports = class Cache {
         continue
       }
 
+      // Detect DMG
+      const extension = extname(name).split('.')[1]
+      if (!name.includes('blockmap') && extension === 'dmg') {
+        dmgUrl = browser_download_url
+      }
+
       const platform = checkPlatform(name)
 
       if (!platform) {
@@ -134,6 +145,10 @@ module.exports = class Cache {
         content_type,
         size: Math.round(size / 1000000 * 10) / 10
       }
+    }
+
+    if (this.latest.platforms.darwin && dmgUrl) {
+      this.latest.platforms.darwin.dmg_url = dmgUrl
     }
 
     console.log(`Finished caching version ${tag_name}`)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -57,7 +57,7 @@ module.exports = ({ cache, config }) => {
     }
 
     res.writeHead(302, {
-      Location: platforms[platform].url
+      Location: platforms[platform].dmg_url || platforms[platform].url
     })
 
     res.end()
@@ -88,7 +88,7 @@ module.exports = ({ cache, config }) => {
     }
 
     res.writeHead(302, {
-      Location: latest.platforms[platform].url
+      Location: latest.platforms[platform].dmg_url || latest.platforms[platform].url
     })
 
     res.end()


### PR DESCRIPTION
Same PR upstream: https://github.com/zeit/hazel/pull/53

---

Note: Downloading the .dmg requires the .zip to exist.

This is because .dmg is served only on the darwin platform, which exists only if there's a .zip.